### PR TITLE
perf: optimize notes retrieval by leveraging indexedDB sorting

### DIFF
--- a/db.js
+++ b/db.js
@@ -220,21 +220,30 @@ export class ActivityPubDB extends EventTarget {
     await tx.done()
   }
 
-  async searchNotes (criteria, { skip = 0, limit = DEFAULT_LIMIT } = {}) {
+  async searchNotes ({attributedTo} = {}, { skip = 0, limit = DEFAULT_LIMIT, sort = -1 } = {}) {
     const tx = this.db.transaction(NOTES_STORE, 'readonly')
-    const index = tx.store.index(PUBLISHED_FIELD)
-
-    const direction = 'prev' // 'prev' for descending order
-    let cursor = await index.openCursor(null, direction)
+    let count = 0
+    const direction = sort >0 ? 'next' : 'prev' // 'prev' for descending order
     const notes = []
+    let cursor = null
 
-    // Skip the required entries
-    for (let i = 0; i < skip && cursor; i++) {
-      cursor = await cursor.continue()
+    const indexName = attributedTo ? ATTRIBUTED_TO_FIELD + ', published' : PUBLISHED_FIELD
+
+    let index = tx.store.index(indexName)
+
+    if(attributedTo) {
+      cursor = await index.openCursor([attributedTo], direction)
+    } else {
+      cursor = await index.openCursor(null, direction)
     }
 
+    // Skip the required entries
+    if(skip) await cursor.advance(skip)
+
     // Collect the required limit of entries
-    for (let i = 0; i < limit && cursor; i++) {
+    while (cursor) {
+      if(count >= limit) break
+      count++
       notes.push(cursor.value)
       cursor = await cursor.continue()
     }

--- a/timeline.js
+++ b/timeline.js
@@ -58,12 +58,15 @@ class ReaderTimeline extends HTMLElement {
     // Remove the button before loading more items
     this.loadMoreBtnWrapper.remove()
 
-    const notes = await db.searchNotes({}, { skip: this.skip, limit: this.limit })
-    notes.forEach(note => this.appendNoteElement(note))
+    let count = 0
+    for await (const note of db.searchNotes({}, { skip: this.skip, limit: this.limit })) {
+      count++
+      this.appendNoteElement(note)
+    }
 
     // Update skip value and determine if there are more items
     this.skip += this.limit
-    this.hasMoreItems = notes.length === this.limit
+    this.hasMoreItems = count === this.limit
 
     // Append the button at the end if there are more items
     if (this.hasMoreItems) {


### PR DESCRIPTION
Problem: Duplicate posts appear on the timeline when visiting a profile's outbox

When I visit the outbox of the profile, it re-adds the notes, even for newly unfollowed accounts. As a result, duplicate posts appear on the timeline. This issue occurs only once; subsequent visits to the same profile/outbox do not result in additional duplications of the posts. I have attempted troubleshooting by modifying the `getNote` and `ingestNote` functions in db.

https://github.com/hyphacoop/reader.distributed.press/pull/7#discussion_r1566414349