### PR TITLE
feat: implement replies for social reader

### DIFF
--- a/example/post.html
+++ b/example/post.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <title>Reader Post</title>
 <style>
-  @import url("../post.css");
   @import url("../common.css");
+  @import url("../post.css");
+  @import url("../post-replies.css");
 </style>
 <div id="post-container">
   <!-- https://staticpub.mauve.moe/helloworld.html -->
@@ -15,7 +16,7 @@
 <script>
   const params = new URLSearchParams(window.location.search);
   // Fallback to a default URL for testing if the parameter is not available
-  const defaultPostUrl = "ipns://hypha.coop/dripline/announcing-dp-social-inbox.ipns.jsonld";
+  const defaultPostUrl = "https://mastodon.mauve.moe/users/mauve/statuses/112690528242160776/";
   const postUrl = params.get("url") || defaultPostUrl;
 
   if (postUrl) {

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   @import url("./timeline.css");
   @import url("./outbox.css");
   @import url("./post.css");
+  @import url("./post-replies.css");
 </style>
 <div class="container">
   <sidebar-nav></sidebar-nav>

--- a/post-replies.css
+++ b/post-replies.css
@@ -1,0 +1,11 @@
+.reply-count {
+  text-align: right;
+  align-self: flex-end;
+}
+
+.reply-count-link{
+    color: var(--rdp-details-color);
+  }
+.reply-count-link:hover{
+    text-decoration: none;
+}

--- a/post-replies.js
+++ b/post-replies.js
@@ -1,5 +1,4 @@
 import { db } from './dbInstance.js'
-import DOMPurify from './dependencies/dompurify/purify.js'
 
 class PostReplies extends HTMLElement {
   static get observedAttributes () {
@@ -40,12 +39,10 @@ class PostReplies extends HTMLElement {
 
   renderReplies (replies) {
     this.innerHTML = '' // Clear existing content
-    if (replies.length === 0) {
-      this.textContent = 'No replies'
-    } else {
+    if (replies.length > 0) {
       replies.forEach(reply => {
-        const replyElement = document.createElement('div')
-        replyElement.innerHTML = DOMPurify.sanitize(reply.content)
+        const replyElement = document.createElement('distributed-post')
+        replyElement.setAttribute('url', reply.id)
         this.appendChild(replyElement)
       })
     }
@@ -78,7 +75,7 @@ class ReplyCount extends HTMLElement {
     this.innerHTML = ''
     const replyCountElement = document.createElement('a')
     replyCountElement.classList.add('reply-count-link')
-    replyCountElement.textContent = `${count} replies`
+    replyCountElement.textContent = `${count} ${count === 1 ? 'reply' : 'replies'}`
     replyCountElement.href = `/post.html?url=${encodeURIComponent(postUrl)}&view=replies`
     this.appendChild(replyCountElement)
   }

--- a/post-replies.js
+++ b/post-replies.js
@@ -1,0 +1,86 @@
+import { db } from './dbInstance.js'
+import DOMPurify from './dependencies/dompurify/purify.js'
+
+class PostReplies extends HTMLElement {
+  static get observedAttributes () {
+    return ['url']
+  }
+
+  connectedCallback () {
+    this.loadReplies(this.getAttribute('url'))
+  }
+
+  async loadReplies (postUrl) {
+    const replies = []
+    console.log('Loading replies for URL:', postUrl)
+    try {
+      // Check if the note has a replies collection and use it if available
+      const note = await db.getNote(postUrl)
+      if (note.replies && typeof note.replies === 'string') {
+        for await (const reply of db.iterateRepliesCollection(note.replies)) {
+          replies.push(reply)
+        }
+      } else {
+        // Fallback to searchNotes with inReplyTo
+        for await (const reply of db.searchNotes({ inReplyTo: postUrl })) {
+          replies.push(reply)
+        }
+      }
+      if (replies.length === 0) {
+        console.log('No replies found for:', postUrl)
+      } else {
+        console.log(`Found ${replies.length} replies for ${postUrl}`, replies)
+      }
+    } catch (error) {
+      console.error('Error loading replies:', error)
+    }
+    this.renderReplies(replies)
+  }
+
+  renderReplies (replies) {
+    this.innerHTML = '' // Clear existing content
+    if (replies.length === 0) {
+      this.textContent = 'No replies'
+    } else {
+      replies.forEach(reply => {
+        const replyElement = document.createElement('div')
+        replyElement.innerHTML = DOMPurify.sanitize(reply.content)
+        this.appendChild(replyElement)
+      })
+    }
+  }
+}
+
+customElements.define('post-replies', PostReplies)
+
+class ReplyCount extends HTMLElement {
+  static get observedAttributes () {
+    return ['url']
+  }
+
+  connectedCallback () {
+    this.loadReplyCount(this.getAttribute('url'))
+  }
+
+  async loadReplyCount (postUrl) {
+    console.log('Loading reply count for URL:', postUrl)
+    try {
+      const count = await db.replyCount(postUrl)
+      this.renderReplyCount(count, postUrl)
+    } catch (error) {
+      console.error('Error loading reply count:', error)
+      this.renderReplyCount(0, postUrl)
+    }
+  }
+
+  renderReplyCount (count, postUrl) {
+    this.innerHTML = ''
+    const replyCountElement = document.createElement('a')
+    replyCountElement.classList.add('reply-count-link')
+    replyCountElement.textContent = `${count} replies`
+    replyCountElement.href = `/post.html?url=${encodeURIComponent(postUrl)}&view=replies`
+    this.appendChild(replyCountElement)
+  }
+}
+
+customElements.define('reply-count', ReplyCount)

--- a/post-replies.js
+++ b/post-replies.js
@@ -17,7 +17,7 @@ class PostReplies extends HTMLElement {
       // Check if the note has a replies collection and use it if available
       const note = await db.getNote(postUrl)
       if (note.replies && typeof note.replies === 'string') {
-        for await (const reply of db.iterateRepliesCollection(note.replies)) {
+        for await (const reply of db.iterateCollection(note.replies, { limit: Infinity })) {
           replies.push(reply)
         }
       } else {

--- a/post.css
+++ b/post.css
@@ -87,7 +87,7 @@
   font-size: 16px;
   color: var(--rdp-text-color);
   padding: 6px;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   overflow-wrap: break-word;
 }
 
@@ -99,8 +99,10 @@
   text-decoration: none;
 }
 
-.post-footer {
-  margin-top: 10px;
+.post-footer, .reply-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-size: 0.875rem;
   color: var(--rdp-details-color);
 }

--- a/post.html
+++ b/post.html
@@ -8,6 +8,7 @@
   @import url("./theme.css");
   @import url("./timeline.css");
   @import url("./post.css");
+  @import url("./post-replies.css");
 </style>
 <div class="container">
   <sidebar-nav></sidebar-nav>

--- a/post.js
+++ b/post.js
@@ -1,6 +1,7 @@
 /* global customElements, HTMLElement */
 import DOMPurify from './dependencies/dompurify/purify.js'
 import { db } from './dbInstance.js'
+import './post-replies.js'
 
 function formatDate (dateString) {
   const options = { year: 'numeric', month: 'short', day: 'numeric' }
@@ -233,6 +234,16 @@ class DistributedPost extends HTMLElement {
     // Append the date container to the footer
     postFooter.appendChild(dateContainer)
 
+    const replyFooter = document.createElement('div')
+    replyFooter.classList.add('reply-footer')
+
+    const replyCountElement = document.createElement('reply-count')
+    replyCountElement.classList.add('reply-count')
+    replyCountElement.setAttribute('url', jsonLdData.id)
+    replyFooter.appendChild(replyCountElement)
+
+    postFooter.appendChild(replyFooter)
+
     // Handle attachments of other Fedi instances
     if (!isSensitive && !jsonLdData.summary && jsonLdData.attachment && jsonLdData.attachment.length > 0) {
       const attachmentsContainer = document.createElement('div')
@@ -264,6 +275,13 @@ class DistributedPost extends HTMLElement {
 
     // Append the whole post container to the custom element
     this.appendChild(postContainer)
+
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('view') === 'replies') {
+      const postReplies = document.createElement('post-replies')
+      postReplies.setAttribute('url', jsonLdData.id)
+      this.after(postReplies)
+    }
   }
 
   // appendField to optionally allow HTML content

--- a/profile.html
+++ b/profile.html
@@ -10,6 +10,7 @@
   @import url("./timeline.css");
   @import url("./outbox.css");
   @import url("./post.css");
+  @import url("./post-replies.css");
 </style>
 <div class="container">
   <sidebar-nav></sidebar-nav>

--- a/timeline.js
+++ b/timeline.js
@@ -94,18 +94,11 @@ class ReaderTimeline extends HTMLElement {
     this.loadMoreBtnWrapper.remove()
     let count = 0
 
-    if (this.sort === 'random') {
-      for await (const note of db.searchNotes({}, { limit: this.limit, sort: this.sort === 'random' ? 0 : (this.sort === 'oldest' ? 1 : -1) })) {
+    const notesToShow = await this.fetchSortedNotes()
+    for (const note of notesToShow) {
+      if (note) {
         this.appendNoteElement(note)
         count++
-      }
-    } else {
-      const notesToShow = await this.fetchSortedNotes()
-      for (const note of notesToShow) {
-        if (note) {
-          this.appendNoteElement(note)
-          count++
-        }
       }
     }
 
@@ -114,7 +107,7 @@ class ReaderTimeline extends HTMLElement {
   }
 
   async fetchSortedNotes () {
-    const notesGenerator = db.searchNotes({}, { skip: this.skip, limit: this.limit, sort: this.sort === 'oldest' ? 1 : -1 })
+    const notesGenerator = db.searchNotes({ timeline: 'following' }, { skip: this.skip, limit: this.limit, sort: this.sort === 'oldest' ? 1 : -1 })
     const notes = []
     for await (const note of notesGenerator) {
       notes.push(note)

--- a/timeline.js
+++ b/timeline.js
@@ -94,26 +94,16 @@ class ReaderTimeline extends HTMLElement {
     this.loadMoreBtnWrapper.remove()
     let count = 0
 
-    const notesToShow = await this.fetchSortedNotes()
-    for (const note of notesToShow) {
-      if (note) {
-        this.appendNoteElement(note)
-        count++
-      }
+    const sortValue = this.sort === 'random' ? 0 : (this.sort === 'oldest' ? 1 : -1)
+
+    // Fetch notes and render them as they become available
+    for await (const note of db.searchNotes({ timeline: 'following' }, { skip: this.skip, limit: this.limit, sort: sortValue })) {
+      this.appendNoteElement(note)
+      count++
     }
 
     this.updateHasMore(count)
     this.appendLoadMoreIfNeeded()
-  }
-
-  async fetchSortedNotes () {
-    const sortValue = this.sort === 'random' ? 0 : (this.sort === 'oldest' ? 1 : -1)
-    const notesGenerator = db.searchNotes({ timeline: 'following' }, { skip: this.skip, limit: this.limit, sort: sortValue })
-    const notes = []
-    for await (const note of notesGenerator) {
-      notes.push(note)
-    }
-    return notes
   }
 
   updateHasMore (count) {

--- a/timeline.js
+++ b/timeline.js
@@ -107,7 +107,8 @@ class ReaderTimeline extends HTMLElement {
   }
 
   async fetchSortedNotes () {
-    const notesGenerator = db.searchNotes({ timeline: 'following' }, { skip: this.skip, limit: this.limit, sort: this.sort === 'oldest' ? 1 : -1 })
+    const sortValue = this.sort === 'random' ? 0 : (this.sort === 'oldest' ? 1 : -1)
+    const notesGenerator = db.searchNotes({ timeline: 'following' }, { skip: this.skip, limit: this.limit, sort: sortValue })
     const notes = []
     for await (const note of notesGenerator) {
       notes.push(note)


### PR DESCRIPTION
https://github.com/hyphacoop/distributed-press-organizing/issues/129

Few concerns:
- It should be able to fetch all the replies without the need to follow or ingest them using `iterateRepliesCollection`. Currently, the replies are visible only when the actor is followed.
- At present, only the replies from the post's actor are visible. It should show the replies of all actors, correct?

Mastodon posts replies:
![Screenshot 2024-07-11 at 4 41 07 PM](https://github.com/user-attachments/assets/7b08a123-8ba7-408f-a547-d9836ef5655a)
![Screenshot 2024-07-11 at 4 40 35 PM](https://github.com/user-attachments/assets/525e31c4-4aef-48d9-97fc-9e38931d5295)

Sutty post replies: https://github.com/hyphacoop/distributed-press-organizing/issues/179
![Screenshot 2024-07-15 at 6 18 03 PM](https://github.com/user-attachments/assets/ee98aa67-5e6d-42a8-98ee-e92b34255fb1)

