### PR TITLE
fix: use .innerHTML with DOMPurify for profile summary to prevent raw html display

### DIFF
--- a/actor-profile.js
+++ b/actor-profile.js
@@ -1,4 +1,5 @@
 import { db } from './dbInstance.js'
+import DOMPurify from './dependencies/dompurify/purify.js'
 
 class ActorProfile extends HTMLElement {
   static get observedAttributes () {
@@ -96,7 +97,7 @@ class ActorProfile extends HTMLElement {
     if (actorInfo.summary) {
       const pUserSummary = document.createElement('div')
       pUserSummary.classList.add('profile-summary')
-      pUserSummary.textContent = `${actorInfo.summary}`
+      pUserSummary.innerHTML = DOMPurify.sanitize(actorInfo.summary)
       actorContainer.appendChild(pUserSummary) // Append to the actor container
     }
 


### PR DESCRIPTION
https://github.com/hyphacoop/reader.distributed.press/issues/23

![Screenshot 2024-07-11 at 4 57 47 PM](https://github.com/user-attachments/assets/baa2991c-75c6-4af4-9626-5465a39ebc4a)
