### PR TITLE
fix(timeline): correctly filter and display posts in timeline

### DIFF
--- a/db.js
+++ b/db.js
@@ -214,44 +214,38 @@ export class ActivityPubDB extends EventTarget {
 
   async * searchNotes ({ attributedTo, inReplyTo, timeline } = {}, { skip = 0, limit = DEFAULT_LIMIT, sort = -1 } = {}) {
     const tx = this.db.transaction(NOTES_STORE, 'readonly')
+
+    // Log the received timeline
+    console.log('Searching notes with timeline:', timeline)
+
     const indexName = timeline ? 'timeline, published' : inReplyTo ? IN_REPLY_TO_FIELD : (attributedTo ? `${ATTRIBUTED_TO_FIELD}, published` : PUBLISHED_FIELD)
+    console.log('Using index:', indexName)
+
     const index = tx.store.index(indexName)
     const direction = sort > 0 ? 'next' : 'prev'
-    let cursor = await index.openCursor(null, direction)
+    let cursor
 
-    if (sort === 0) { // Random sort
-      const totalNotes = await index.count()
-      for (let i = 0; i < limit; i++) {
-        const randomSkip = Math.floor(Math.random() * totalNotes)
-        cursor = await index.openCursor()
-        if (randomSkip > 0) {
-          await cursor.advance(randomSkip)
-        }
-        if (cursor) {
-          yield cursor.value
-        }
-      }
+    if (timeline) {
+      cursor = await index.openCursor([timeline], direction)
+    } else if (inReplyTo) {
+      cursor = await index.openCursor(inReplyTo, direction)
+    } else if (attributedTo) {
+      cursor = await index.openCursor([attributedTo], direction)
     } else {
-      if (timeline) {
-        // Ensure we're not fetching replies for the timeline
-        cursor = await index.openCursor([timeline], direction)
-      } else if (attributedTo) {
-        cursor = await index.openCursor([attributedTo], direction)
-      } else if (inReplyTo) {
-        cursor = await index.openCursor(inReplyTo, direction)
-      } else {
-        cursor = await index.openCursor(null, direction)
-      }
+      cursor = await index.openCursor(null, direction)
+    }
 
-      if (skip) await cursor.advance(skip)
+    if (cursor && skip) {
+      await cursor.advance(skip) // Only advance if cursor is not null
+    }
 
-      let count = 0
-      while (cursor) {
-        if (count >= limit) break
-        count++
-        yield cursor.value
-        cursor = await cursor.continue()
-      }
+    let count = 0
+    while (cursor) {
+      if (count >= limit) break // Stop after reaching the limit
+      console.log('Yielding note:', cursor.value) // Log each note fetched
+      yield cursor.value
+      cursor = await cursor.continue()
+      count++
     }
 
     await tx.done

--- a/timeline.js
+++ b/timeline.js
@@ -98,8 +98,11 @@ class ReaderTimeline extends HTMLElement {
 
     // Fetch notes and render them as they become available
     for await (const note of db.searchNotes({ timeline: 'following' }, { skip: this.skip, limit: this.limit, sort: sortValue })) {
-      this.appendNoteElement(note)
-      count++
+      // Exclude replies from appearing in the timeline
+      if (!note.inReplyTo) {
+        this.appendNoteElement(note)
+        count++
+      }
     }
 
     this.updateHasMore(count)


### PR DESCRIPTION
Still not able to view the posts.

If I remove the `timeline` from searchNotes then it's showing but with all the replies
```
  async * searchNotes ({ attributedTo, inReplyTo } = {}, { skip = 0, limit = DEFAULT_LIMIT, sort = -1 } = {}) {
    const tx = this.db.transaction(NOTES_STORE, 'readonly')
    const indexName = inReplyTo ? IN_REPLY_TO_FIELD : (attributedTo ? `${ATTRIBUTED_TO_FIELD}, published` : PUBLISHED_FIELD)
    const index = tx.store.index(indexName)
    const direction = sort > 0 ? 'next' : 'prev'
    let cursor = await index.openCursor(null, direction)

    if (sort === 0) { // Random sort
      const totalNotes = await index.count()
      for (let i = 0; i < limit; i++) {
        const randomSkip = Math.floor(Math.random() * totalNotes)
        cursor = await index.openCursor()
        if (randomSkip > 0) {
          await cursor.advance(randomSkip)
        }
        if (cursor) {
          yield cursor.value
        }
      }
    } else {
      if (attributedTo) {
        cursor = await index.openCursor([attributedTo], direction)
      } else if (inReplyTo) {
        cursor = await index.openCursor(inReplyTo, direction)
      } else {
        cursor = await index.openCursor(null, direction)
      }

      if (skip) await cursor.advance(skip)

      let count = 0
      while (cursor) {
        if (count >= limit) break
        count++
        yield cursor.value
        cursor = await cursor.continue()
      }
    }

    await tx.done
  }
```
![Screenshot 2024-08-27 at 11 48 42 AM](https://github.com/user-attachments/assets/58ba343e-15ba-4356-aa11-507550c64744)

